### PR TITLE
Fix links in `make.jl`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,14 +6,14 @@ using BundleAdjustmentModels
 pages = ["Introduction" => "index.md", "Reference" => "reference.md"]
 
 makedocs(
-  sitename = "BundleAdjustmentModels",
+  sitename = "BundleAdjustmentModels.jl",
   format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
   modules = [BundleAdjustmentModels],
   pages = pages,
 )
 
 deploydocs(
-  repo = "github.com/JuliaSmoothOptimizers/BundleAdjustmentModels",
+  repo = "github.com/JuliaSmoothOptimizers/BundleAdjustmentModels.jl",
   push_preview = true,
   devbranch = "main",
 )


### PR DESCRIPTION
I believe this is the reason why the docs weren't deployed anymore.