### PR TITLE
decrease allocations in residual evaluation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 CodecBzip2 = "0.7"
 DataFrames = "1.2"
 JLD2 = "0.4"
-NLPModels = "0.17"
+NLPModels = "0.17, 0.18"
 julia = "^1.3.1"
 
 [extras]

--- a/src/BundleAdjustmentNLSFunctions.jl
+++ b/src/BundleAdjustmentNLSFunctions.jl
@@ -129,7 +129,7 @@ function residuals!(
       v = view(vs, pnt_range)
       P = view(Ps, pnt_range)
       r = view(rs, (2 * k - 1):(2 * k))
-      projection!(x, c, r, k, v, P)
+      projection!(x, c, r, v, P)
     end
   end
   return rs
@@ -155,7 +155,6 @@ function projection!(
   k2,
   f,
   r2::AbstractVector,
-  idx::Int,
   k::AbstractVector,
   P1::AbstractVector
 )
@@ -170,7 +169,7 @@ function projection!(
   return r2
 end
 
-projection!(x, c, r2, k, v, P1) = projection!(x, view(c, 1:3), view(c, 4:6), c[7], c[8], c[9], r2, k, v, P1)
+projection!(x, c, r2, v, P1) = projection!(x, view(c, 1:3), view(c, 4:6), c[7], c[8], c[9], r2, v, P1)
 
 function scaling_factor(point::AbstractVector, k1::AbstractFloat, k2::AbstractFloat)
   sq_norm_point = dot(point, point)

--- a/src/BundleAdjustmentNLSFunctions.jl
+++ b/src/BundleAdjustmentNLSFunctions.jl
@@ -152,12 +152,12 @@ function projection!(
   P1::AbstractVector
 )
   θ = norm(r)
-  k .= r / θ
+  k .= r ./ θ
   cross!(P1, k, p3)
   P1 .*= sin(θ)
-  P1 .+= cos(θ) * p3 .+ (1 - cos(θ)) * dot(k, p3) * k .+ t
-  r2[1] = -P1[1] / P1[3]
-  r2[2] = -P1[2] / P1[3]
+  P1 .+= cos(θ) .* p3 .+ (1 - cos(θ)) .* dot(k, p3) .* k .+ t
+  r2[1] = -P1[1] ./ P1[3]
+  r2[2] = -P1[2] ./ P1[3]
   s = scaling_factor(r2, k1, k2)
   r2 .*= f * s
   return r2
@@ -165,7 +165,7 @@ end
 
 projection!(x, c, r2, v, P1) = projection!(x, view(c, 1:3), view(c, 4:6), c[7], c[8], c[9], r2, v, P1)
 
-function scaling_factor(point::AbstractVector, k1::AbstractFloat, k2::AbstractFloat)
+function scaling_factor(point::AbstractVector, k1, k2)
   sq_norm_point = dot(point, point)
   return 1 + sq_norm_point * (k1 + k2 * sq_norm_point)
 end

--- a/src/BundleAdjustmentNLSFunctions.jl
+++ b/src/BundleAdjustmentNLSFunctions.jl
@@ -113,24 +113,17 @@ function residuals!(
   vs::AbstractVector,
   Ps::AbstractVector
 )
-  q, re = divrem(nobs, nthreads())
-  if re != 0
-    q += 1
-  end
-
-  @threads for t = 1:nthreads()
-    @simd for k = (1 + (t - 1) * q):min(t * q, nobs)
-      cam_index = cam_indices[k]
-      pnt_index = pnt_indices[k]
-      pnt_range = ((pnt_index - 1) * 3 + 1):((pnt_index - 1) * 3 + 3)
-      cam_range = (3 * npts + (cam_index - 1) * 9 + 1):(3 * npts + (cam_index - 1) * 9 + 9)
-      x = view(xs, pnt_range)
-      c = view(xs, cam_range)
-      v = view(vs, pnt_range)
-      P = view(Ps, pnt_range)
-      r = view(rs, (2 * k - 1):(2 * k))
-      projection!(x, c, r, v, P)
-    end
+  @simd for k = 1:nobs
+    cam_index = cam_indices[k]
+    pnt_index = pnt_indices[k]
+    pnt_range = ((pnt_index - 1) * 3 + 1):((pnt_index - 1) * 3 + 3)
+    cam_range = (3 * npts + (cam_index - 1) * 9 + 1):(3 * npts + (cam_index - 1) * 9 + 9)
+    x = view(xs, pnt_range)
+    c = view(xs, cam_range)
+    v = view(vs, pnt_range)
+    P = view(Ps, pnt_range)
+    r = view(rs, (2 * k - 1):(2 * k))
+    projection!(x, c, r, v, P)
   end
   return rs
 end

--- a/src/BundleAdjustmentNLSFunctions.jl
+++ b/src/BundleAdjustmentNLSFunctions.jl
@@ -163,7 +163,8 @@ function projection!(
   cross!(P1, k, p3)
   P1 .*= sin(θ)
   P1 .+= cos(θ) * p3 .+ (1 - cos(θ)) * dot(k, p3) * k .+ t
-  r2 .= -P1[1:2] / P1[3]
+  r2[1] = -P1[1] / P1[3]
+  r2[2] = -P1[2] / P1[3]
   s = scaling_factor(r2, k1, k2)
   r2 .*= f * s
   return r2


### PR DESCRIPTION
This PR's objective is to decrease the amount of allocations when evaluating the residual. On problem-49-7776-pre/ladybug, I get

#### Before

```
julia> @benchmark residual!($nls, $(nls.meta.x0), $r)
BenchmarkTools.Trial: 109 samples with 1 evaluation.
 Range (min … max):  35.592 ms … 98.198 ms  ┊ GC (min … max):  0.00% … 7.13%
 Time  (median):     43.779 ms              ┊ GC (median):    13.09%
 Time  (mean ± σ):   46.145 ms ±  9.294 ms  ┊ GC (mean ± σ):  12.04% ± 3.36%

       ▃▃▃██▅▆
  ▅▅▁▁▇███████▇█▁▅▅▅▅▅▁▁▁▅▁▅▁▁▁▅▁▁▁▁▁▁▁▁▁▁▅▁▁▁▁▁▁▁▁▁▅▁▁▁▁▁▅▁▅ ▅
  35.6 ms      Histogram: log(frequency) by time      87.3 ms <

 Memory estimate: 46.31 MiB, allocs estimate: 1156139.
```

#### After

```
 julia> @benchmark residual!($nls, $(nls.meta.x0), $r)
BenchmarkTools.Trial: 129 samples with 1 evaluation.
 Range (min … max):  31.432 ms … 67.156 ms  ┊ GC (min … max):  0.00% … 0.00%
 Time  (median):     39.505 ms              ┊ GC (median):    16.44%
 Time  (mean ± σ):   38.756 ms ±  4.884 ms  ┊ GC (mean ± σ):  12.02% ± 7.62%

    ▂               ▅▆▄█▁
  ▅▅█▆▆▆▄▄▃▅▁▁▁▁▃▅▅▅█████▆▅▄▃▃▃▃▄▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▃▃▁▁▁▁▁▁▁▁▁▁▃ ▃
  31.4 ms         Histogram: frequency by time        56.2 ms <

 Memory estimate: 34.65 MiB, allocs estimate: 1028765.
 ```

There are still lots of allocations that don't seem necessary.

Any ideas?

cc @AntoninKns 