### PR TITLE
Bump version 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BundleAdjustmentModels"
 uuid = "0bf3e898-7c79-4b38-9ca6-2d9cc6573905"
 authors = ["AntoninKns <antonin.kenens@polymtl.ca>"]
-version = "0.1.1"
+version = "0.2"
 
 [deps]
 CodecBzip2 = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"


### PR DESCRIPTION
Bumping version of BundleAdjustmentModels to 0.2.
Concerning the version of the dependancies I was wondering if we force NLPModels 0.19 or if we allow a broader range of versions. It is important to notice that having NLPModels version 0.18 or lower will result in allocations of memory in the code due to the increments.