### PR TITLE
Corrections issue 39-47-51

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,22 +97,27 @@ julia> model = BundleAdjustmentModel("../path/to/file/problem-49-7776-pre.txt.bz
 BundleAdjustmentModel{Float64, Vector{Float64}}
 ```
 
-You can then evaluate the residual and jacobian function ( or their in-place version ):
+You can then evaluate the residual and jacobian function ( or their in-place version ) from NLPModels.
+
+```julia
+julia> using NLPModels
+```
 
 ```julia
 julia> Fx = residual(model, model.meta.x0)
 63686-element Vector{Float64}:
  -9.020226301243213
  11.263958304987227
- -1.8332297149469525
-  5.304698960898122
- -4.332321480806684
   ⋮
-  0.23044496991071384
-  0.04927878647407624
-  0.47289578243411867
  -0.01443314653496941
  -0.4486499211288866
+```
+
+Before using the ``jac_op_residual`` it is required to call ``jac_structure_residual!``.
+
+```
+julia> jac_structure_residual!(model, model.rows, model.cols)
+([1, 1  …  63686, 63686], [1, 2  …  23768, 23769])
 ```
 
 ```julia

--- a/README.md
+++ b/README.md
@@ -90,12 +90,45 @@ julia> model = BundleAdjustmentModel("problem-49-7776-pre", "ladybug")
 BundleAdjustmentModel{Float64, Vector{Float64}}
 ```
 
-You can also construct a nonlinear least-squares model by giving the constructor the path to the archive :
+You can also construct a nonlinear least-squares model by giving the constructor the path to the archive:
 
 ```julia
 julia> model = BundleAdjustmentModel("../path/to/file/problem-49-7776-pre.txt.bz2")
 BundleAdjustmentModel{Float64, Vector{Float64}}
 ```
+
+You can then evaluate the residual and jacobian function ( or their in-place version ):
+
+```julia
+julia> Fx = residual(model, model.meta.x0)
+63686-element Vector{Float64}:
+ -9.020226301243213
+ 11.263958304987227
+ -1.8332297149469525
+  5.304698960898122
+ -4.332321480806684
+  ⋮
+  0.23044496991071384
+  0.04927878647407624
+  0.47289578243411867
+ -0.01443314653496941
+ -0.4486499211288866
+```
+
+```julia
+julia> Jx = jac_op_residual(model, model.meta.x0)
+Linear operator
+  nrow: 63686
+  ncol: 23769
+  eltype: Float64
+  symmetric: false
+  hermitian: false
+  nprod:   0
+  ntprod:  0
+  nctprod: 0
+```
+
+There is no second order information available fore these problems in the module.
 
 Delete unneeded artifacts and free up disk space with `delete_ba_artifact!`:
 

--- a/test/testBundleAdjustmentAllocations.jl
+++ b/test/testBundleAdjustmentAllocations.jl
@@ -11,25 +11,25 @@ if VERSION ≥ VersionNumber(1, 7, 3)
     @test residual_alloc(model, r) == 0
   end
 
-  @testset "jac_structure allocations" begin
+  @testset "jac_structure_residual allocations" begin
     df = problems_df()
     filter_df = df[(df.name .== "problem-49-7776-pre"), :]
     name, group = get_first_name_and_group(filter_df)
     model = BundleAdjustmentModel(name, group)
 
-    jac_structure!(model, model.rows, model.cols)
-    jac_structure_alloc(model) = @allocated jac_structure!(model, model.rows, model.cols)
-    @test jac_structure_alloc(model) == 0
+    jac_structure_residual!(model, model.rows, model.cols)
+    jac_structure_residual_alloc(model) = @allocated jac_structure_residual!(model, model.rows, model.cols)
+    @test jac_structure_residual_alloc(model) == 0
   end
 
-  @testset "jac_coord allocations" begin
+  @testset "jac_coord_residual allocations" begin
     df = problems_df()
     filter_df = df[(df.name .== "problem-49-7776-pre"), :]
     name, group = get_first_name_and_group(filter_df)
     model = BundleAdjustmentModel(name, group)
 
-    jac_coord!(model, model.meta.x0, model.vals)
-    jac_coord_alloc(model) = @allocated jac_coord!(model, model.meta.x0, model.vals)
-    @test jac_coord_alloc(model) == 0
+    jac_coord_residual!(model, model.meta.x0, model.vals)
+    jac_coord_residual_alloc(model) = @allocated jac_coord_residual!(model, model.meta.x0, model.vals)
+    @test jac_coord_residual_alloc(model) == 0
   end
 end

--- a/test/testBundleAdjustmentModels.jl
+++ b/test/testBundleAdjustmentModels.jl
@@ -62,6 +62,7 @@ end
   name, group = get_first_name_and_group(filter_df)
   model = BundleAdjustmentModel(name, group)
   Fx = residual(model, model.meta.x0)
+  jac_structure_residual!(model, model.rows, model.cols)
   Jx = jac_op_residual(model, model.meta.x0)
 
   @test 1.70677551536496222019e+08 ≈ norm(Jx' * Fx)
@@ -70,6 +71,7 @@ end
   name, group = get_first_name_and_group(filter_df)
   model = BundleAdjustmentModel(name, group)
   Fx = residual(model, model.meta.x0)
+  jac_structure_residual!(model, model.rows, model.cols)
   Jx = jac_op_residual(model, model.meta.x0)
 
   @test 1.64335338754470020533e+08 ≈ norm(Jx' * Fx)
@@ -78,6 +80,7 @@ end
   name, group = get_first_name_and_group(filter_df)
   model = BundleAdjustmentModel(name, group)
   Fx = residual(model, model.meta.x0)
+  jac_structure_residual!(model, model.rows, model.cols)
   Jx = jac_op_residual(model, model.meta.x0)
 
   @test 2.39615629098822921515e+07 ≈ norm(Jx' * Fx)


### PR DESCRIPTION
Renaming ``jac_structure!`` to ``jac_structure_residual!`` and ``jac_coord`` to ``jac_coord_residual!`` to solve #39 and improve compatibility with other modules.

Adding informations in the README.md regarding ``residual`` and ``jac_op_residual`` functions and the lack of second order information to solve #39.

Changing the docstring to create a BundleAdjustmentModel to solve #39.

Fixing calls to ``increment!`` in ``jac_structure_residual!`` to solve #47.

Fixing ``jac_op_residual`` function by removing call to ``jac_structure_residual!`` to solve #51.