### PR TITLE
Adding jprod_residual! and jtprod_residual!

### DIFF
--- a/src/BundleAdjustmentNLSFunctions.jl
+++ b/src/BundleAdjustmentNLSFunctions.jl
@@ -248,3 +248,25 @@ function NLPModels.jac_coord_residual!(
   end
   return vals
 end
+
+function NLPModels.jprod_residual!(nls, x, v, Jv)
+  @lencheck nls.meta.nvar x v
+  @lencheck nls.nls_meta.nequ Jv
+  increment!(nls, :neval_jprod_residual)
+  rows, cols = jac_structure_residual(nls)
+  vals = jac_coord_residual(nls, x)
+  decrement!(nls, :neval_jac_residual)
+  coo_prod!(rows, cols, vals, v, Jv)
+  return Jv
+end
+
+function NLPModels.jtprod_residual!(nls, x, v, Jtv)
+  @lencheck nls.meta.nvar x Jtv
+  @lencheck nls.nls_meta.nequ v
+  increment!(nls, :neval_jtprod_residual)
+  rows, cols = jac_structure_residual(nls)
+  vals = jac_coord_residual(nls, x)
+  decrement!(nls, :neval_jac_residual)
+  coo_prod!(cols, rows, vals, v, Jtv)
+  return Jtv
+end

--- a/test/testBundleAdjustmentModels.jl
+++ b/test/testBundleAdjustmentModels.jl
@@ -117,6 +117,81 @@ end
   @test 2.39615629098822921515e+07 ≈ norm(Jx' * Fx)
 end
 
+@testset "test jprod_residual and jtprod_residual" begin
+  df = problems_df()
+  filter_df = df[(df.name .== "problem-16-22106-pre"), :]
+  name = filter_df[1, :name]
+  model = BundleAdjustmentModel(name)
+  Fx = residual(model, model.meta.x0)
+  S = typeof(model.meta.x0)
+  meta_nls = nls_meta(model)
+  rows = Vector{Int}(undef, meta_nls.nnzj)
+  cols = Vector{Int}(undef, meta_nls.nnzj)
+  vals = S(undef, meta_nls.nnzj)
+  Jv = S(undef, meta_nls.nequ)
+  Jtv = S(undef, meta_nls.nvar)
+  jac_structure_residual!(model, rows, cols)
+  jac_coord_residual!(model, model.meta.x0, vals)
+  Jx = jac_op_residual!(model, rows, cols, vals, Jv, Jtv)
+  Jtu = S(undef, meta_nls.nvar)
+  jtprod_residual!(model, model.meta.x0, Fx, Jtu)
+
+  @test 1.70677551536496222019e+08 ≈ norm(Jtu)
+
+  Ju = S(undef, meta_nls.nequ)
+  jprod_residual!(model, model.meta.x0, model.meta.x0, Ju)
+
+  @test norm(Jx * model.meta.x0) ≈ norm(Ju)
+
+  filter_df = df[(df.name .== "problem-21-11315-pre"), :]
+  name = filter_df[1, :name]
+  model = BundleAdjustmentModel(name)
+  Fx = residual(model, model.meta.x0)
+  S = typeof(model.meta.x0)
+  meta_nls = nls_meta(model)
+  rows = Vector{Int}(undef, meta_nls.nnzj)
+  cols = Vector{Int}(undef, meta_nls.nnzj)
+  vals = S(undef, meta_nls.nnzj)
+  Jv = S(undef, meta_nls.nequ)
+  Jtv = S(undef, meta_nls.nvar)
+  jac_structure_residual!(model, rows, cols)
+  jac_coord_residual!(model, model.meta.x0, vals)
+  Jx = jac_op_residual!(model, rows, cols, vals, Jv, Jtv)
+  Jtu = S(undef, meta_nls.nvar)
+  jtprod_residual!(model, model.meta.x0, Fx, Jtu)
+
+  @test 1.64335338754470020533e+08 ≈ norm(Jtu)
+
+  Ju = S(undef, meta_nls.nequ)
+  jprod_residual!(model, model.meta.x0, model.meta.x0, Ju)
+
+  @test norm(Jx * model.meta.x0) ≈ norm(Ju)
+
+  filter_df = df[(df.name .== "problem-49-7776-pre"), :]
+  name = filter_df[1, :name]
+  model = BundleAdjustmentModel(name)
+  Fx = residual(model, model.meta.x0)
+  S = typeof(model.meta.x0)
+  meta_nls = nls_meta(model)
+  rows = Vector{Int}(undef, meta_nls.nnzj)
+  cols = Vector{Int}(undef, meta_nls.nnzj)
+  vals = S(undef, meta_nls.nnzj)
+  Jv = S(undef, meta_nls.nequ)
+  Jtv = S(undef, meta_nls.nvar)
+  jac_structure_residual!(model, rows, cols)
+  jac_coord_residual!(model, model.meta.x0, vals)
+  Jx = jac_op_residual!(model, rows, cols, vals, Jv, Jtv)
+  Jtu = S(undef, meta_nls.nvar)
+  jtprod_residual!(model, model.meta.x0, Fx, Jtu)
+
+  @test 2.39615629098822921515e+07 ≈ norm(Jtu)
+
+  Ju = S(undef, meta_nls.nequ)
+  jprod_residual!(model, model.meta.x0, model.meta.x0, Ju)
+
+  @test norm(Jx * model.meta.x0) ≈ norm(Ju)
+end
+
 @testset "test delete_ba_artifact!()" begin
   df = problems_df()
   sort!(df, [:nequ, :nvar])


### PR DESCRIPTION
Adding a workaround of ``jprod_residual!`` and ``jtprod_residual!`` in order for BundleAdjustmentModels to work better with other packages from JSO. The true detailed version of ``jprod_residual!`` and ``jtprod_residual!`` should be added later in order to avoid allocations and have better performance for these functions.