### PR TITLE
Add benchmarks with ADNLPModels.jl

### DIFF
--- a/benchmarks.jl
+++ b/benchmarks.jl
@@ -1,0 +1,72 @@
+using BundleAdjustmentModels
+using ADNLPModels
+using NLPModels
+using Printf
+
+debug = false
+check_jacobian = false
+df = problems_df()
+# df = df[ ( df.nequ .≤ 600000 ) .& ( df.nvar .≤ 100000 ), :]
+nproblems = size(df)[1]
+
+@printf("| %21s | %7s | %7s | %22s | %15s |\n", "problem", "nequ", "nvar", "backend", "coord_residual")
+for i = 1:nproblems
+  name_pb = df[i, :name]
+
+  # Smaller problem of the collection
+  debug && (i == 1) && (name_pb = "problem-49-7776-pre")
+  debug && (i ≠ 1) && continue
+
+  ## BundleAdjustementModels
+  nls = BundleAdjustmentModel(name_pb)
+  meta_nls = nls_meta(nls)
+  Fx = similar(nls.meta.x0, meta_nls.nequ)
+  rows = Vector{Int}(undef, meta_nls.nnzj)
+  cols = Vector{Int}(undef, meta_nls.nnzj)
+  vals = similar(nls.meta.x0, meta_nls.nnzj)
+
+  # warm-start
+  residual(nls, nls.meta.x0)
+  residual!(nls, nls.meta.x0, Fx)
+  jac_structure_residual!(nls, rows, cols)
+  jac_coord_residual!(nls, nls.meta.x0, vals)
+
+  # benchmarks
+  start_timer = time()
+  jac_coord_residual!(nls, nls.meta.x0, vals)
+  end_timer = time()
+  timer_coord_residual = end_timer - start_timer
+  @printf("| %21s | %7s | %7s | %22s | %6.5f seconds |\n", name_pb, nls.nls_meta.nequ, nls.meta.nvar, "BundleAdjustmentModels", timer_coord_residual)
+
+  ## ADNLPModels
+  function F!(Fx, x)
+    residual!(nls, x, Fx)
+  end
+  nls2 = ADNLSModel!(F!, nls.meta.x0, meta_nls.nequ, nls.meta.lvar, nls.meta.uvar, jacobian_residual_backend = ADNLPModels.SparseADJacobian,
+                                                                                   jacobian_backend = ADNLPModels.EmptyADbackend,
+                                                                                   hessian_backend = ADNLPModels.EmptyADbackend,
+                                                                                   hessian_residual_backend = ADNLPModels.EmptyADbackend)
+  meta_nls2 = nls_meta(nls2)
+  rows2 = Vector{Int}(undef, meta_nls2.nnzj)
+  cols2 = Vector{Int}(undef, meta_nls2.nnzj)
+  vals2 = similar(nls2.meta.x0, meta_nls2.nnzj)
+
+  # Warm-start
+  jac_structure_residual!(nls2, rows2, cols2)
+  jac_coord_residual!(nls2, nls2.meta.x0, vals2)
+
+  # benchmarks
+  start_timer = time()
+  jac_coord_residual!(nls2, nls2.meta.x0, vals2)
+  end_timer = time()
+  timer2_coord_residual = end_timer - start_timer
+  @printf("| %21s | %7s | %7s | %22s | %6.5f seconds |\n", name_pb, nls2.nls_meta.nequ, nls2.meta.nvar, "ADNLPModels", timer2_coord_residual)
+
+  if check_jacobian
+    println(meta_nls.nnzj)
+    println(meta_nls2.nnzj)
+    J_nls = sparse(rows, cols, vals)
+    J_nls2 = sparse(rows2, cols2, vals2)
+    norm(J_nls - J_nls2) |> println
+  end
+end

--- a/src/BundleAdjustmentNLSFunctions.jl
+++ b/src/BundleAdjustmentNLSFunctions.jl
@@ -144,7 +144,9 @@ function projection!(
   f,
   r2::AbstractVector,
 )
-  θ = norm(r)
+  # θ = norm(r)
+  θ = sqrt(dot(r, r))
+
   #k .= r ./ θ
   k1 = r[1] / θ
   k2 = r[2] / θ


### PR DESCRIPTION
I have the following results with the smaller problems:
```
|               problem |    nequ |    nvar |                backend |  coord_residual |
|  problem-16-22106-pre |  167436 |   66462 | BundleAdjustmentModels | 0.07969 seconds |
|  problem-16-22106-pre |  167436 |   66462 |            ADNLPModels | 0.22904 seconds |
|  problem-21-11315-pre |   72910 |   34134 | BundleAdjustmentModels | 0.03291 seconds |
|  problem-21-11315-pre |   72910 |   34134 |            ADNLPModels | 0.09916 seconds |
|  problem-39-18060-pre |  127102 |   54531 | BundleAdjustmentModels | 0.05802 seconds |
|  problem-39-18060-pre |  127102 |   54531 |            ADNLPModels | 0.18114 seconds |
|  problem-50-20431-pre |  147934 |   61743 | BundleAdjustmentModels | 0.06764 seconds |
|  problem-50-20431-pre |  147934 |   61743 |            ADNLPModels | 0.21581 seconds |
|   problem-49-7776-pre |   63686 |   23769 | BundleAdjustmentModels | 0.02919 seconds |
|   problem-49-7776-pre |   63686 |   23769 |            ADNLPModels | 0.09215 seconds |
|  problem-73-11032-pre |   92244 |   33753 | BundleAdjustmentModels | 0.04247 seconds |
|  problem-73-11032-pre |   92244 |   33753 |            ADNLPModels | 0.13800 seconds |
```